### PR TITLE
feat: support pre-trained models and export results to CSV

### DIFF
--- a/config/experiment_with_pretrained.toml
+++ b/config/experiment_with_pretrained.toml
@@ -1,0 +1,43 @@
+# Experiment configuration with pre-trained models
+# Usage: python main.py -c config/experiment_with_pretrained.toml
+
+[experiment]
+# Datasets to process (image_size=28)
+datasets = [
+    "BloodMNIST",
+    "BreastMNIST",
+    "DermaMNIST",
+    "OrganAMNIST",
+    "OrganCMNIST",
+    "OrganSMNIST",
+    "PneumoniaMNIST",
+    "RetinaMNIST",
+    "TissueMNIST",
+]
+# Note: ChestMNIST and OCTMNIST were trained with image_size=64
+# They require a separate experiment config with image_size=64
+
+# Image size must match the trained models
+image_size = 28
+
+# Number of images to generate for FID computation
+num_generated_images = 100
+
+# Output file for results
+results_output = "results/experiment_results.csv"
+
+# Pre-trained model weights (dataset name -> weights path)
+[experiment.weights]
+BloodMNIST = "models/blood_epoch-1_all-images_image-size-28_batch-8.weights.h5"
+BreastMNIST = "models/breast_epoch-1_all-images_image-size-28_batch-8.weights.h5"
+DermaMNIST = "models/derma_epoch-1_all-images_image-size-28_batch-8.weights.h5"
+OrganAMNIST = "models/organa_epoch-1_all-images_image-size-28_batch-8.weights.h5"
+OrganCMNIST = "models/organc_epoch-1_all-images_image-size-28_batch-8.weights.h5"
+OrganSMNIST = "models/organs_epoch-1_all-images_image-size-28_batch-8.weights.h5"
+PneumoniaMNIST = "models/pneumonia_epoch-1_all-images_image-size-28_batch-8.weights.h5"
+RetinaMNIST = "models/retina_epoch-1_all-images_image-size-28_batch-8.weights.h5"
+TissueMNIST = "models/tissue_epoch-1_all-images_image-size-28_batch-8.weights.h5"
+
+# Models trained with image_size=64 (incompatible with this config):
+# ChestMNIST = "models/chest_epoch-1_all-images_image-size-64_batch-8.weights.h5"
+# OCTMNIST = "models/OCT_epoch-1_all-images_image-size-64_batch-8.weights.h5"

--- a/main.py
+++ b/main.py
@@ -1,13 +1,16 @@
 import argparse
+import csv
+import logging
+import os
 
-from src.domain.use_cases.experiment import Experiment
+from src.domain.use_cases.experiment import Experiment, ExperimentResult
 from src.infrastructure.configuration import ExperimentConfiguration
 from src.infrastructure.loaders import MedMNISTDatasetLoader
 from src.infrastructure.logging import setup_logging
 from src.infrastructure.metrics import FIDSimilarityMetric, ResNetMSDVariabilityMetric
-from src.infrastructure.tensorflow.diffusion_model import (
-    TensorFlowDiffusionModel,
-)
+from src.infrastructure.tensorflow.diffusion_model import TensorFlowDiffusionModel
+
+logger = logging.getLogger(__name__)
 
 
 def parse_args(argv=None):
@@ -24,6 +27,76 @@ def parse_args(argv=None):
     return parser.parse_args(argv)
 
 
+def create_model_factory(image_size: int, num_channels: int = 3):
+    """
+    Create a factory function for TensorFlowDiffusionModel.
+
+    Parameters
+    ----------
+    image_size : int
+        Image size for the model.
+    num_channels : int
+        Number of image channels.
+
+    Returns
+    -------
+    Callable[[str | None], Model]
+        Factory function that creates a model, optionally loading weights.
+    """
+
+    def factory(weights_path: str | None) -> TensorFlowDiffusionModel:
+        model = TensorFlowDiffusionModel(
+            image_size=image_size,
+            num_channels=num_channels,
+        )
+        if weights_path is not None:
+            model.load(weights_path)
+        return model
+
+    return factory
+
+
+def save_results_to_csv(results: list[ExperimentResult], output_path: str) -> None:
+    """
+    Save experiment results to a CSV file.
+
+    Parameters
+    ----------
+    results : list[ExperimentResult]
+        List of experiment results.
+    output_path : str
+        Path to the output CSV file.
+    """
+    # Ensure output directory exists
+    output_dir = os.path.dirname(output_path)
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
+
+    fieldnames = [
+        "dataset",
+        "model_weights",
+        "variability",
+        "similarity",
+        "num_samples",
+        "num_generated",
+    ]
+
+    with open(output_path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for result in results:
+            writer.writerow({
+                "dataset": result.dataset,
+                "model_weights": result.model_weights or "",
+                "variability": f"{result.variability:.6f}",
+                "similarity": f"{result.similarity:.6f}",
+                "num_samples": result.num_samples,
+                "num_generated": result.num_generated,
+            })
+
+    logger.info(f"Results saved to {output_path}")
+
+
 def main(config_path: str = None):
     # 1. Setup Logging
     setup_logging()
@@ -37,7 +110,7 @@ def main(config_path: str = None):
     dataset_loader = MedMNISTDatasetLoader()
     variability_metric = ResNetMSDVariabilityMetric()
     similarity_metric = FIDSimilarityMetric()
-    model = TensorFlowDiffusionModel(
+    model_factory = create_model_factory(
         image_size=config.image_size,
         num_channels=3,
     )
@@ -50,9 +123,14 @@ def main(config_path: str = None):
         dataset_loader=dataset_loader,
         variability_metric=variability_metric,
         similarity_metric=similarity_metric,
-        model=model,
+        model_factory=model_factory,
+        weights=config.weights,
+        num_generated_images=config.num_generated_images,
     )
-    experiment.run()
+    results = experiment.run()
+
+    # 5. Save results to CSV
+    save_results_to_csv(results, config.results_output)
 
 
 if __name__ == "__main__":

--- a/results/experiment_results.csv
+++ b/results/experiment_results.csv
@@ -1,0 +1,10 @@
+dataset,model_weights,variability,similarity,num_samples,num_generated
+BloodMNIST,models/blood_epoch-1_all-images_image-size-28_batch-8.weights.h5,96.829742,313.230616,11959,100
+BreastMNIST,models/breast_epoch-1_all-images_image-size-28_batch-8.weights.h5,93.252808,296.329880,546,100
+DermaMNIST,models/derma_epoch-1_all-images_image-size-28_batch-8.weights.h5,123.667755,175.797859,7007,100
+OrganAMNIST,models/organa_epoch-1_all-images_image-size-28_batch-8.weights.h5,135.075363,191.241691,34561,100
+OrganCMNIST,models/organc_epoch-1_all-images_image-size-28_batch-8.weights.h5,122.134583,138.878635,12975,100
+OrganSMNIST,models/organs_epoch-1_all-images_image-size-28_batch-8.weights.h5,123.285439,143.799505,13932,100
+PneumoniaMNIST,models/pneumonia_epoch-1_all-images_image-size-28_batch-8.weights.h5,71.859741,164.918281,4708,100
+RetinaMNIST,models/retina_epoch-1_all-images_image-size-28_batch-8.weights.h5,84.982437,573.980403,1080,100
+TissueMNIST,models/tissue_epoch-1_all-images_image-size-28_batch-8.weights.h5,66.984505,142.514055,165466,100

--- a/src/domain/use_cases/experiment.py
+++ b/src/domain/use_cases/experiment.py
@@ -1,4 +1,6 @@
 import logging
+from dataclasses import dataclass
+from typing import Callable
 
 from src.domain.entities.dataset import Dataset
 from src.domain.entities.tensor import Tensor
@@ -9,11 +11,23 @@ from src.domain.interfaces.model import Model
 logger = logging.getLogger(__name__)
 
 
+@dataclass
+class ExperimentResult:
+    """Result of a single dataset experiment."""
+
+    dataset: str
+    model_weights: str | None
+    variability: float
+    similarity: float
+    num_samples: int
+    num_generated: int
+
+
 class Experiment:
     """
     Orchestrates the variability and similarity experiment using dependency injection.
     """
-    
+
     def __init__(
         self,
         datasets: list[str],
@@ -22,19 +36,33 @@ class Experiment:
         dataset_loader: DatasetLoader,
         variability_metric: VariabilityMetric,
         similarity_metric: SimilarityMetric,
-        model: Model
+        model_factory: Callable[[str | None], Model],
+        weights: dict[str, str] | None = None,
+        num_generated_images: int = 100,
     ):
         """
         Create an Experiment configured with datasets, loading/training components, and evaluation metrics.
-        
-        Parameters:
-            datasets (list[str]): Names of datasets to process.
-            max_samples (int | None): Maximum number of samples to load per dataset, or None to use all samples.
-            image_size (int): Target image size (pixels) used when loading datasets.
-            dataset_loader (DatasetLoader): Component responsible for loading datasets.
-            variability_metric (VariabilityMetric): Component used to compute dataset variability.
-            similarity_metric (SimilarityMetric): Component used to compute similarity between real and generated data.
-            model (Model): Model used for training and image generation.
+
+        Parameters
+        ----------
+        datasets : list[str]
+            Names of datasets to process.
+        max_samples : int | None
+            Maximum number of samples to load per dataset, or None to use all samples.
+        image_size : int
+            Target image size (pixels) used when loading datasets.
+        dataset_loader : DatasetLoader
+            Component responsible for loading datasets.
+        variability_metric : VariabilityMetric
+            Component used to compute dataset variability.
+        similarity_metric : SimilarityMetric
+            Component used to compute similarity between real and generated data.
+        model_factory : Callable[[str | None], Model]
+            Factory function that creates a Model, optionally loading weights from a path.
+        weights : dict[str, str] | None
+            Mapping of dataset name to weights file path. If None, models will be trained.
+        num_generated_images : int
+            Number of images to generate for similarity computation.
         """
         self.datasets = datasets
         self.max_samples = max_samples
@@ -42,7 +70,9 @@ class Experiment:
         self.dataset_loader = dataset_loader
         self.variability_metric = variability_metric
         self.similarity_metric = similarity_metric
-        self.model = model
+        self.model_factory = model_factory
+        self.weights = weights or {}
+        self.num_generated_images = num_generated_images
         
     def load_dataset(self, dataset_name: str) -> Dataset:
         """
@@ -72,69 +102,92 @@ class Experiment:
         """
         return self.variability_metric.compute(dataset)
     
-    def train_model(self, dataset: Dataset):
-        """Train the model on the dataset."""
-        self.model.train(dataset)
-    
-    def generate_images(self, n: int = 100) -> Tensor:
-        """
-        Generate a batch of images from the experiment's model.
-        
-        Parameters:
-            n (int): Number of images to generate.
-        
-        Returns:
-            Tensor: Tensor containing the generated images.
-        """
-        return self.model.generate_images(n=n)
-    
     def compute_similarity(self, dataset: Dataset, generated: Tensor) -> float:
         """
         Compute similarity between a real dataset and generated images using the configured similarity metric.
-        
-        Parameters:
-            dataset (Dataset): The real dataset to compare against.
-            generated (Tensor): Tensor of generated images to compare with the real dataset.
-        
-        Returns:
-            float: Similarity score produced by the configured similarity metric.
+
+        Parameters
+        ----------
+        dataset : Dataset
+            The real dataset to compare against.
+        generated : Tensor
+            Tensor of generated images to compare with the real dataset.
+
+        Returns
+        -------
+        float
+            Similarity score produced by the configured similarity metric.
         """
         return self.similarity_metric.compute(dataset, generated)
-    
-    def run(self):
+
+    def run(self) -> list[ExperimentResult]:
         """
         Orchestrate the full experiment pipeline across configured datasets.
-        
-        For each dataset name in self.datasets this method loads the dataset, computes its variability, trains the injected model, generates images, and computes similarity between real and generated samples. Progress and key results are logged. If processing a dataset raises an exception, the error is logged for that dataset and the exception is re-raised.
+
+        For each dataset, this method:
+        1. Loads the dataset
+        2. Computes its variability
+        3. Loads pre-trained model weights (or trains if no weights provided)
+        4. Generates images
+        5. Computes similarity between real and generated samples
+
+        Returns
+        -------
+        list[ExperimentResult]
+            Results for each dataset processed.
         """
         logger.info("Starting MedMNIST Variability & Similarity Experiment")
-        
+        results: list[ExperimentResult] = []
+
         for dataset_name in self.datasets:
             logger.info(f"Processing {dataset_name}...")
-            
+
             try:
                 # 1. Load Dataset
                 dataset = self.load_dataset(dataset_name)
                 logger.info(f"Loaded {dataset_name} with {len(dataset)} samples.")
-                
+
                 # 2. Compute Variability
                 variability_score = self.compute_variability(dataset)
-                logger.info(f"Variability (Mean Squared Distance to Centroid) for {dataset_name}: {variability_score:.4f}")
-                
-                # 3. Train Model
-                logger.info(f"Training diffusion model on {dataset_name}...")
-                self.train_model(dataset)
-                
+                logger.info(
+                    f"Variability (Mean Squared Distance to Centroid) for "
+                    f"{dataset_name}: {variability_score:.4f}"
+                )
+
+                # 3. Create model and load weights (or train)
+                weights_path = self.weights.get(dataset_name)
+                if weights_path:
+                    logger.info(f"Loading pre-trained weights from {weights_path}")
+                    model = self.model_factory(weights_path)
+                else:
+                    logger.info(f"No weights provided, training model on {dataset_name}...")
+                    model = self.model_factory(None)
+                    model.train(dataset, dataset_name=dataset_name)
+
                 # 4. Generate Images
-                logger.info(f"Generating images for {dataset_name}...")
-                generated_images = self.generate_images(n=100)
-                
+                logger.info(
+                    f"Generating {self.num_generated_images} images for {dataset_name}..."
+                )
+                generated_images = model.generate_images(n=self.num_generated_images)
+
                 # 5. Compute Similarity
                 similarity_score = self.compute_similarity(dataset, generated_images)
-                logger.info(f"Similarity (FID-like) for {dataset_name}: {similarity_score:.4f}")
+                logger.info(f"Similarity (FID) for {dataset_name}: {similarity_score:.4f}")
+
+                # Store result
+                result = ExperimentResult(
+                    dataset=dataset_name,
+                    model_weights=weights_path,
+                    variability=variability_score,
+                    similarity=similarity_score,
+                    num_samples=len(dataset),
+                    num_generated=self.num_generated_images,
+                )
+                results.append(result)
 
             except Exception as error:
                 logger.error(f"Failed to process {dataset_name}: {error}")
                 raise error
-        
+
         logger.info("Experiment completed.")
+        return results

--- a/src/infrastructure/configuration.py
+++ b/src/infrastructure/configuration.py
@@ -192,32 +192,84 @@ class GenerationConfiguration:
 
 @dataclass
 class ExperimentConfiguration:
+    """
+    Configuration for running experiments with pre-trained models.
+
+    Attributes
+    ----------
+    datasets : list[str]
+        List of dataset names to process.
+    weights : dict[str, str]
+        Mapping of dataset name to weights file path.
+    max_samples : int | None
+        Maximum samples per dataset (None = all).
+    image_size : int
+        Image size for loading datasets and model.
+    num_generated_images : int
+        Number of images to generate for similarity computation.
+    results_output : str
+        Path to save results CSV file.
+    variability_metric : str
+        Type of variability metric to use.
+    similarity_metric : str
+        Type of similarity metric to use.
+    model_type : str
+        Type of generative model.
+    """
+
     datasets: list[str]
+    weights: dict[str, str] | None = None
     max_samples: int | None = None
-    image_size: int = 224
+    image_size: int = 28
+    num_generated_images: int = 100
+    results_output: str = "results/experiment_results.csv"
     variability_metric: str = "resnet_msd"
     similarity_metric: str = "fid"
     model_type: str = "diffusion"
+
+    def get_weights_path(self, dataset_name: str) -> str | None:
+        """
+        Get the weights file path for a given dataset.
+
+        Parameters
+        ----------
+        dataset_name : str
+            Name of the dataset.
+
+        Returns
+        -------
+        str | None
+            Path to weights file, or None if not configured.
+        """
+        if self.weights is None:
+            return None
+        return self.weights.get(dataset_name)
 
     @classmethod
     def load(cls, config_path: str) -> "ExperimentConfiguration":
         """
         Load experiment configuration from a TOML file.
-        
-        Parameters:
-            config_path (str): Filesystem path to a TOML file containing an "experiment" table.
-        
-        Returns:
-            ExperimentConfiguration: Instance populated from the "experiment" table; fields not present use their dataclass defaults.
-        
-        Raises:
-            FileNotFoundError: If no file exists at `config_path`.
+
+        Parameters
+        ----------
+        config_path : str
+            Filesystem path to a TOML file containing an "experiment" table.
+
+        Returns
+        -------
+        ExperimentConfiguration
+            Instance populated from the "experiment" table.
+
+        Raises
+        ------
+        FileNotFoundError
+            If no file exists at `config_path`.
         """
         if not os.path.exists(config_path):
             raise FileNotFoundError(f"Configuration file not found at {config_path}")
-            
+
         with open(config_path, "rb") as f:
             data = tomllib.load(f)
-            
+
         experiment_data = data.get("experiment", {})
         return cls(**experiment_data)


### PR DESCRIPTION
## Summary

- Add support for loading pre-trained model weights instead of training
- Export experiment results to CSV file with variability and similarity scores
- Use model factory pattern for flexible model instantiation

## Changes

### Configuration (`ExperimentConfiguration`)
- `weights`: dict mapping dataset name to weights file path
- `num_generated_images`: number of images to generate for FID (default: 100)
- `results_output`: path to output CSV file

### Experiment
- Accepts `model_factory` instead of a single model instance
- Loads pre-trained weights if configured, otherwise trains
- Returns `list[ExperimentResult]` with all metrics

### Results CSV
Columns: `dataset`, `model_weights`, `variability`, `similarity`, `num_samples`, `num_generated`

## Usage

```bash
python main.py -c config/experiment_with_pretrained.toml
```

## Notes

- ChestMNIST and OCTMNIST trained with image_size=64 (separate config needed)
- Other 9 datasets trained with image_size=28

## Test plan

- [x] All 65 tests pass
- [x] Configuration loading verified
- [ ] Manual test with pre-trained models

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notes de version

* **Nouvelles fonctionnalités**
  * Chargement de modèles pré-entraînés pour les expériences.
  * Export automatique des résultats d'expérience au format CSV.
  * Support de configurations d'expériences avec plusieurs ensembles de données.

* **Configuration**
  * Taille d'image par défaut ajustée.
  * Paramètres configurables pour le nombre d'images générées et le chemin de sortie.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->